### PR TITLE
fix(package): declare ext depends on 'vscode.git'

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "diffy-explain-ai",
   "displayName": "Diffy - AI Commit Messages with Context",
   "description": "Generate Commit Message for You or Explains The Changed Code Using Git Diff And OpenAi In Natural Language",
-  "version": "1.6.0",
+  "version": "1.6.1",
   "publisher": "hitclaw",
   "engines": {
     "vscode": "^1.105.0"
@@ -384,5 +384,8 @@
     "gpt-tokenizer": "^2.6.1",
     "openai": "^4.7.0",
     "simple-git": "^3.16.0"
-  }
+  },
+  "extensionDependencies": [
+    "vscode.git"
+  ]
 }


### PR DESCRIPTION
According to https://code.visualstudio.com/api/references/vscode-api#extensions
> When depending on the API of another extension add an extensionDependencies-entry to package.json, and use the [getExtension](https://code.visualstudio.com/api/references/vscode-api#extensions.getExtension)-function and the [exports](https://code.visualstudio.com/api/references/vscode-api#Extension.exports)-property…

Fix #65

